### PR TITLE
Use CloudFront CDN for rotating Volvo graphic on homepage

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -116,8 +116,8 @@
               <h5 class="card-title"><img src="https://i.imgur.com/M7mUF0l.png"/> Volvo V70 (3rd Generation)</h5>
               
                 <video id="video" playsinline controls loop muted autoplay>
-                  <source src="http://pickup.paperplane.io/cars/VolvoSlowMotionEdited.mp4" type="video/mp4" />
-                  <track kind="metadata" src="http://pickup.paperplane.io/cars/volvo-slowmo.vtt"></track>
+                  <source src="https://d255f9fqc5psux.cloudfront.net/Storage/VolvoSlowMotionEdited.mp4" type="video/mp4"/>
+                  <track kind="metadata" src="https://d255f9fqc5psux.cloudfront.net/Storage/volvo-slowmo.vtt"></track>
                 </video> 
              
 
@@ -287,7 +287,7 @@
       previewThumbnails: {
           enabled: true,
           src: [
-              'https://cors-anywhere.herokuapp.com/pickup.paperplane.io/cars/volvo-slowmo-reduced.vtt',
+              'https://cors-anywhere.herokuapp.com/d255f9fqc5psux.cloudfront.net/Storage/volvo-slowmo.vtt',
           ],
       },
     });


### PR DESCRIPTION
## Summary

While most of the assets on the site that were originally on `pickup.paperplane.io` have been migrated, the remaining rotating Volvo video, sprites and VTT file remained on the now inaccessible sub-site.

To fix this issue, the assets were moved to an S3 bucket with IAM set such that the public cannot directly access the assets via S3, and instead need to go through the provided CloudFront CDN links.

This provides improved performance, along with a functioning rotating Volvo V70 :)

## Test Plan
Manual sanity testing on localhost.